### PR TITLE
run julia demos to generate assets before passing into Literate

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 DemoCards = "311a05b2-6137-4a5a-b473-18580a3d38b5"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"

--- a/docs/demos/simplest_demopage/dependencies/part2/simple_cameraman.jl
+++ b/docs/demos/simplest_demopage/dependencies/part2/simple_cameraman.jl
@@ -1,0 +1,9 @@
+# ---
+# cover: assets/cameraman.png
+# ---
+
+using TestImages, FileIO
+
+img = testimage("cameraman")
+save("assets/cameraman.png", img)
+img

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -84,14 +84,16 @@ function makedemos(source::String;
     mkpath(absolute_root)
     mkpath(joinpath(absolute_root, "covers")) # consistent to card template
 
+    # make a copy before pipeline because `save_democards` modifies card path
+    source_files = map(x->x.path, flatten(page))
+
     # pipeline
     copy_assets(absolute_root, page)
-    save_democards(absolute_root, page)
+    save_democards(absolute_root, page) # WARNING: julia cards are reconfigured here
     save_cover(joinpath(absolute_root, "covers"), page)
     generate(joinpath(absolute_root, "index.md"), page)
 
     # pipeline: generate postprocess callback function
-    source_files = map(x->x.path, flatten(page))
     postprocess_cb = ()->begin
         @info "Redirect URL: redirect docs-edit-link for demos in $(source) directory."
         foreach(source_files) do source_file


### PR DESCRIPTION
closes #5 

#7 introduces a postprocess callback function, this PR runs each julia demo files to generate potential assets, so that following usage becomes possible (and it's really useful):

```julia
using TestImages, FileIO

img = testimage("cameraman")
save("assets/cameraman.png", img) # hide

# ![cover](assets/cameraman.png)
```
