### PR TITLE
test against Julia 1.3 in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1
+  - julia_version: 1.3
   - julia_version: nightly
 platform:
   - x86


### PR DESCRIPTION
Looks like `1` is no longer linked to "latest stable release" anymore.