### PR TITLE
[Julia] support comments before YAML frontmatter

### DIFF
--- a/docs/quickstart/usage_example/basics/configure_card.md
+++ b/docs/quickstart/usage_example/basics/configure_card.md
@@ -18,3 +18,6 @@ description: This demo show you how to pass additional meta info of card to Demo
 
 ---
 ```
+
+Of course, you have to make sure the `---` flag shows at the first line of the markdown file,
+otherwise DemoCards would just read them as normal contents.

--- a/docs/quickstart/usage_example/julia_demos/1.julia_demo.jl
+++ b/docs/quickstart/usage_example/julia_demos/1.julia_demo.jl
@@ -1,3 +1,7 @@
+#! /usr/bin/julia
+
+# comments are allowed before YAML frontmatter
+
 # ---
 # title: Write your demo in julia
 # cover: assets/literate.png
@@ -49,3 +53,7 @@ img = testimage("lena")
 # # ---
 # ```
 
+# !!! tip
+#     Comments are allowed before frontmatter, but it would only be appeared in the julia source
+#     codes. Normally, you may only want to add magic comments and license information before the
+#     YAML frontmatter.

--- a/src/types/julia.jl
+++ b/src/types/julia.jl
@@ -129,7 +129,8 @@ function save_democards(card_dir::String,
     end
 
     # remove YAML frontmatter
-    _, body = split_frontmatter(read(src_path, String))
+    src_header, _, body = split_frontmatter(read(src_path, String))
+    isempty(strip(src_header)) || (src_header *= "\n\n")
 
     # insert header badge
     header = "#md # [![]($download_badge)]($(cardname).jl)"
@@ -178,6 +179,6 @@ function save_democards(card_dir::String,
     # 5. filter out source file
     mktempdir(card_dir) do tmpdir
         @suppress Literate.script(src_path, tmpdir; credit=credit)
-        mv(joinpath(tmpdir, basename(src_path)), src_path, force=true)
+        write(src_path, src_header, read(joinpath(tmpdir, basename(src_path)), String))
     end
 end

--- a/test/assets/card/julia/title_8.jl
+++ b/test/assets/card/julia/title_8.jl
@@ -1,0 +1,13 @@
+#! /usr/local/bin
+
+# comments are allowed before frontmatter
+
+# empty lines are allowed, too
+
+#---
+#title: Custom Title
+#id: custom_id
+#---
+
+# This is the content
+

--- a/test/assets/card/markdown/title_7.md
+++ b/test/assets/card/markdown/title_7.md
@@ -1,0 +1,8 @@
+
+
+---
+title: Custom Title
+id: custom_id
+---
+
+This is the content

--- a/test/types/julia.jl
+++ b/test/types/julia.jl
@@ -45,6 +45,11 @@
             @test title_7.title == "Custom Title"
             @test title_7.description == "This is the content"
 
+            title_8 = JuliaDemoCard("title_8.jl")
+            @test title_8.id == "custom_id"
+            @test title_8.title == "Custom Title"
+            @test title_8.description == "This is the content"
+
             description_1 = JuliaDemoCard("description_1.jl")
             @test description_1.id == "Custom-Title"
             @test description_1.title == "Custom Title"

--- a/test/types/markdown.jl
+++ b/test/types/markdown.jl
@@ -40,6 +40,11 @@
             @test title_6.title == "Custom Title"
             @test title_6.description == "This is the content"
 
+            title_7 = MarkdownDemoCard("title_7.md")
+            @test title_7.id == "custom_id"
+            @test title_7.title == "Custom Title"
+            @test title_7.description == "This is the content"
+
             description_1 = MarkdownDemoCard("description_1.md")
             @test description_1.id == "Custom-Title"
             @test description_1.title == "Custom Title"


### PR DESCRIPTION
partially address https://github.com/johnnychen94/DemoCards.jl/issues/43

Now DemoCards would successfully recognize the YAML frontmatter if lines before it are all comments and empty lines

```
# /usr/bin/julia

# source code comments

# ---
# title: plot example
# ---
```

but note that YAML frontmatter is still not recognized in the following case, we can't make too strong an assumption of what users intend to do here, it could be plain markdown contents here.

```
# /usr/bin/julia

x = 1

# ---
# title: plot example
# ---
```

cc: @deathgodbxx