### PR TITLE
add hidden flag for cards

### DIFF
--- a/docs/quickstart/usage_example/basics/config.json
+++ b/docs/quickstart/usage_example/basics/config.json
@@ -3,6 +3,8 @@
   "order": [
     "simple_markdown_demo.md",
     "configure_card.md",
-    "configure_sec_and_page.md"
+    "configure_sec_and_page.md",
+    "hide_your_card_from_index.md",
+    "hidden_card.jl"
   ]
 }

--- a/docs/quickstart/usage_example/basics/hidden_card.jl
+++ b/docs/quickstart/usage_example/basics/hidden_card.jl
@@ -1,0 +1,15 @@
+#---
+#hidden: true
+#id: hidden_card
+#---
+
+# # This is a hidden card
+
+# This card doesn't get displayed in [quickstart index page](@ref quickstart) page and can only be
+# viewed with relink `[hidden card](@ref hidden_card)`.
+
+# Note that hidden cards are still processed by DemoCards to get you necessary assets.
+
+using Images, TestImages
+
+imresize(testimage("camera"); ratio=0.25)

--- a/docs/quickstart/usage_example/basics/hide_your_card_from_index.md
+++ b/docs/quickstart/usage_example/basics/hide_your_card_from_index.md
@@ -1,0 +1,26 @@
+---
+title: Hide your card from page index layout
+description: This demo shows you how to hide your card in page layout.
+---
+
+There are cases that you want to hide one card in the generated page layout and only provide the
+entrance via reflink. For example, you have multiple version of demos and you only want to set the
+latest one as the default and provide legacy versions as reflink in the latest page.
+
+This can be done by setting `hidden: false` in the frontmatter, for example:
+
+```markdown
+---
+hidden: true
+id: hidden_card
+---
+```
+
+By doing this, this page is not shown in the generated index page, the only way to visit it is
+through URLs. Usually, you can use Documenter's [reflink
+feature](https://juliadocs.github.io/Documenter.jl/dev/man/syntax/#@ref-link) to provide a reflink
+to the hidden page.
+
+For example, `[hidden card](@ref hidden_card)` generates a reflink to the [hidden page](@ref
+hidden_card), note that it doesn't get displayed in [quickstart index page](@ref quickstart).
+

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -142,7 +142,13 @@ function generate(page::DemoPage, templates)
 end
 
 function generate(cards::AbstractVector{<:AbstractDemoCard}, template)
-    mapreduce(*, cards; init="") do x
+    # for those hidden cards, only generate the necessary assets and files, but don't add them into
+    # the index.md page
+    foreach(filter(x->x.hidden, cards)) do x
+        generate(x, template)
+    end
+
+    mapreduce(*, filter(x->!x.hidden, cards); init="") do x
         generate(x, template)
     end
 end

--- a/src/types/card.jl
+++ b/src/types/card.jl
@@ -66,6 +66,8 @@ function load_config(card::T, key) where T <: AbstractDemoCard
         return get(config, key, get_default_title(card))
     elseif key == "description"
         return get(config, key, card.title)
+    elseif key == "hidden"
+        return get(config, key, false)
     else
         throw(ArgumentError("Unrecognized key $(key) for $(T)"))
     end

--- a/src/types/julia.jl
+++ b/src/types/julia.jl
@@ -38,6 +38,7 @@ Supported items are:
 * `description`: a multi-line description to this file, will be displayed when the demo card is hovered. By default it uses `title`.
 * `id`: specify the `id` tag for cross-references. By default it's infered from the filename, e.g., `simple_demo` from `simple demo.md`.
 * `title`: one-line description to this file, will be displayed under the cover image. By default, it's the name of the file (without extension).
+* `hidden`: whether this card is shown in the layout of index page. The default value is `false`.
 
 An example of the front matter (note the leading `#`):
 
@@ -58,11 +59,12 @@ mutable struct JuliaDemoCard <: AbstractDemoCard
     id::String
     title::String
     description::String
+    hidden::Bool
 end
 
 function JuliaDemoCard(path::String)::JuliaDemoCard
     # first consturct an incomplete democard, and then load the config
-    card = JuliaDemoCard(path, "", "", "", "")
+    card = JuliaDemoCard(path, "", "", "", "", false)
 
     card.cover = load_config(card, "cover")
     card.title = load_config(card, "title")
@@ -70,6 +72,7 @@ function JuliaDemoCard(path::String)::JuliaDemoCard
     card.id    = load_config(card, "id")
     # default description requires a title
     card.description = load_config(card, "description")
+    card.hidden = load_config(card, "hidden")
     return card
 end
 

--- a/src/types/markdown.jl
+++ b/src/types/markdown.jl
@@ -34,6 +34,7 @@ Supported items are:
 * `description`: a multi-line description to this file, will be displayed when the demo card is hovered. By default it uses `title`.
 * `id`: specify the `id` tag for cross-references. By default it's infered from the filename, e.g., `simple_demo` from `simple demo.md`.
 * `title`: one-line description to this file, will be displayed under the cover image. By default, it's the name of the file (without extension).
+* `hidden`: whether this card is shown in the layout of index page. The default value is `false`.
 
 An example of the front matter:
 
@@ -54,11 +55,12 @@ mutable struct MarkdownDemoCard <: AbstractDemoCard
     id::String
     title::String
     description::String
+    hidden::Bool
 end
 
 function MarkdownDemoCard(path::String)::MarkdownDemoCard
     # first consturct an incomplete democard, and then load the config
-    card = MarkdownDemoCard(path, "", "", "", "")
+    card = MarkdownDemoCard(path, "", "", "", "", false)
 
     card.cover = load_config(card, "cover")
     card.title = load_config(card, "title")
@@ -66,6 +68,7 @@ function MarkdownDemoCard(path::String)::MarkdownDemoCard
     card.id    = load_config(card, "id")
     # default description requires a title
     card.description = load_config(card, "description")
+    card.hidden = load_config(card, "hidden")
     return card
 end
 

--- a/test/assets/page/hidden/sec/hidden1.jl
+++ b/test/assets/page/hidden/sec/hidden1.jl
@@ -1,0 +1,5 @@
+#---
+#hidden: true
+#---
+
+# This is a hidden julia card

--- a/test/assets/page/hidden/sec/hidden2.md
+++ b/test/assets/page/hidden/sec/hidden2.md
@@ -1,0 +1,5 @@
+---
+hidden: true
+---
+
+This is a hidden markdown card

--- a/test/assets/page/hidden/sec/normal.md
+++ b/test/assets/page/hidden/sec/normal.md
@@ -1,0 +1,5 @@
+---
+hidden: false
+---
+
+This card is a normal card that shows in the page index

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -21,4 +21,16 @@
         @test @suppress_err path == joinpath("democards", "default", "index.md")
         @test theme == joinpath("democards", "gridtheme.css")
     end
+
+    @testset "hidden" begin
+        index_md = @suppress_err preview_demos(joinpath(root, "page", "hidden"); require_html=false)
+        # test only one card is shown in index.md
+        @test_reference joinpath("references", "hidden_index.txt") read(index_md, String)
+
+        # check that assets are still normally generated even if they are hidden from index.md
+        page_dir = dirname(index_md)
+        @test readdir(page_dir) == ["covers", "index.md", "sec"]
+        @test readdir(joinpath(page_dir, "covers")) == ["democards_logo.svg"]
+        @test readdir(joinpath(page_dir, "sec")) == ["hidden1.ipynb", "hidden1.jl", "hidden1.md", "hidden2.md", "normal.md"]
+    end
 end

--- a/test/references/hidden_index.txt
+++ b/test/references/hidden_index.txt
@@ -1,0 +1,37 @@
+# Hidden
+
+# Sec
+
+
+```@raw html
+<div class="card-section">
+```
+
+```@raw html
+<div class="card">
+<div class="card-cover">
+<div class="card-description">
+```
+This card is a normal card that shows in the page index
+```@raw html
+</div>
+```
+[![card-cover-image](covers/democards_logo.svg)](@ref Normal)
+```@raw html
+</div>
+<div class="card-text">
+```
+
+[Normal](@ref Normal)
+
+```@raw html
+</div>
+</div>
+```
+
+
+
+```@raw html
+</div>
+```
+


### PR DESCRIPTION
This enables you to not showing the card in the card layout of the
generated index.md page.


requires #60 to pass the tests