### PR TITLE
suppress runtime stdout/stderr information

### DIFF
--- a/src/DemoCards.jl
+++ b/src/DemoCards.jl
@@ -13,6 +13,15 @@ const template_filename = "index.md"
 # directly copy these folders without processing
 const ignored_dirnames = ["assets"]
 
+function verbose_mode()
+    if haskey(ENV, "DOCUMENTER_DEBUG")
+        rst = ENV["DOCUMENTER_DEBUG"]
+        return lowercase(strip(rst)) == "true"
+    else
+        return false
+    end
+end
+
 include("compat.jl")
 
 include("types/card.jl")

--- a/src/types/julia.jl
+++ b/src/types/julia.jl
@@ -119,7 +119,8 @@ function save_democards(card_dir::String,
             # modules created with Module() does not have include defined
             # abspath is needed since this will call `include_relative`
             Core.eval(m, :(include(x) = Base.include($m, abspath(x))))
-            Core.eval(m, :(include($cardname * ".jl")))
+            gen_assets() = Core.eval(m, :(include($cardname * ".jl")))
+            verbose_mode() ? gen_assets() : @suppress gen_assets()
 
             # WARNING: card.path is modified here
             card.path = cardname*".jl"


### PR DESCRIPTION
```julia
# test.jl

println("stdout")
@info "information"
@warn "warning"
@error "error"
```

Now `preview_demos` and `makedemos` won't print any information to stdout unless the environment variable `DOCUMENTER_DEBUG` is set to `true`.

Preview:

```julia
julia> preview_demos("test.jl")
[ Info: SetupDemoCardsDirectory: setting up preview_page directory.
[ Info: SetupBuildDirectory: setting up build directory.
...
```

```julia
julia> ENV["DOCUMENTER_DEBUG"]
"true"

julia> preview_demos("test.jl")
[ Info: SetupDemoCardsDirectory: setting up preview_page directory.
stdout
[ Info: information
┌ Warning: warning
└ @ Main.##260 /private/var/folders/c0/p23z1x6x3jg_qtqsy_r421y40000gn/T/jl_d8GxyI/src/democards/preview_page/preview_section/test.jl:11
┌ Error: error
└ @ Main.##260 /private/var/folders/c0/p23z1x6x3jg_qtqsy_r421y40000gn/T/jl_d8GxyI/src/democards/preview_page/preview_section/test.jl:12
[ Info: SetupBuildDirectory: setting up build directory.
...
```

