### PR TITLE
support author with URL in markdown format

### DIFF
--- a/docs/quickstart/usage_example/basics/configure_card.md
+++ b/docs/quickstart/usage_example/basics/configure_card.md
@@ -2,7 +2,7 @@
 title: Configure your card
 cover: assets/logo.svg
 id: configure_your_card
-author: Johnny Chen
+author: "[Johnny Chen](https://github.com/johnnychen94); Jane Doe"
 date: 2020-09-13
 description: This demo show you how to pass additional meta info of card to DemoCards.jl
 ---
@@ -44,13 +44,20 @@ For example, the markdown file of this page uses the following frontmatter:
 title: Configure your card
 cover: assets/logo.svg
 id: configure_your_card
-author: Johnny Chen
+author: "[Johnny Chen](https://github.com/johnnychen94); Jane Doe"
 date: 2020-09-13
 description: This demo show you how to pass additional meta info of card to DemoCards.jl
 ---
-
 ```
 
 As you can see, if configured, there will be badges for `author` and `date` info. If there are
 multiple authors, they could be splitted by semicolon `;`. For example, `author: Jane Doe; John Roe`
 would generate two author badges.
+
+!!! tip
+    If `author` is configured as markdown url format, then the generated badge will be clickable.
+
+!!! warning
+    A badly formatted YAML frontmatter will currently trigger a build failure with perhaps hard to
+    understand error. Sometimes, you need to assist YAML parser by explicitly quoting the content
+    with `""`. See the author field above as an instance.

--- a/docs/quickstart/usage_example/julia_demos/1.julia_demo.jl
+++ b/docs/quickstart/usage_example/julia_demos/1.julia_demo.jl
@@ -7,7 +7,7 @@
 # id: juliademocard_example
 # cover: assets/literate.png
 # date: 2020-09-13
-# author: Johnny Chen
+# author: "[Johnny Chen](https://github.com/johnnychen94)"
 # julia: 1.0.1
 # description: This demo shows you how to write your demo in julia
 # ---

--- a/src/preview.jl
+++ b/src/preview.jl
@@ -162,7 +162,7 @@ function generate_or_copy_pagedir(src_path, build_dir)
         page_dir = src_path
         cp(page_dir, abspath(build_dir, basename(page_dir)); force=true)
     else
-        throw(ArgumentError("failed to parse demo page structure from path: $src_path"))
+        throw(ArgumentError("failed to parse demo page structure from path: $src_path. There might be some invalid demo files."))
     end
 
     return page_dir

--- a/src/types/card.jl
+++ b/src/types/card.jl
@@ -90,8 +90,19 @@ function make_badges(card::AbstractDemoCard)
         for author in split(card.author, ';')
             # TODO: also split on "and"
             isempty(author) && continue
-            author_str = HTTP.escapeuri(strip(author))
-            push!(badges, "![Author](https://img.shields.io/badge/Author-$(author_str)-blue)")
+
+            m = match(regex_md_url, author)
+            if isnothing(m)
+                author_str = HTTP.escapeuri(strip(author))
+                push!(badges, "![Author](https://img.shields.io/badge/Author-$(author_str)-blue)")
+            else
+                # when markdown url is detected, create a link for it
+                # author: [Johnny Chen](https://github.com/johnnychen94)
+                name, url = strip.(m.captures)
+                name = HTTP.escapeuri(name)
+                badge_str = "[![Author](https://img.shields.io/badge/Author-$(name)-blue)]($url)"
+                push!(badges, badge_str)
+            end
         end
     end
     if card.date != DateTime(0)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -193,7 +193,14 @@ function parse(T::Val, card::AbstractDemoCard)
     config = parse(T, body)
     # frontmatter has higher priority
     if !isempty(frontmatter)
-        merge!(config, YAML.load(join(frontmatter, "\n")))
+        yaml_config = try
+            YAML.load(join(frontmatter, "\n"))
+        catch err
+            @warn "failed to parse YAML frontmatter, please double check the format"
+            println(stderr, frontmatter)
+            rethrow(err)
+        end
+        merge!(config, yaml_config)
     end
 
     return config

--- a/test/assets/card/julia/author_with_md_url.jl
+++ b/test/assets/card/julia/author_with_md_url.jl
@@ -1,0 +1,5 @@
+# ---
+# author: "[Johnny Chen](https://github.com/johnnychen94); Jane Doe"
+# ---
+
+# author with markdown url

--- a/test/assets/card/markdown/author_with_md_url.md
+++ b/test/assets/card/markdown/author_with_md_url.md
@@ -1,0 +1,5 @@
+---
+author: "[Johnny Chen](https://github.com/johnnychen94); Jane Doe"
+---
+
+author with markdown url

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -37,4 +37,20 @@
     @testset "throw_error" begin
         @suppress_err @test_throws LoadError preview_demos(joinpath(root, "broken_demo.jl"); throw_error=true)
     end
+
+    @testset "badges" begin
+        @testset "author" begin
+            for (dir, file) in [
+                ("julia", joinpath(root, "card", "julia", "author_with_md_url.jl")),
+                ("markdown", joinpath(root, "card", "markdown", "author_with_md_url.md"))
+            ]
+                page_dir = @suppress_err preview_demos(file; theme="grid", require_html=false)
+                md_file = joinpath(page_dir, dir, "author_with_md_url.md")
+                @test isfile(md_file)
+                line = read(md_file, String)
+                @test occursin("[![Author](https://img.shields.io/badge/Author-Johnny%20Chen-blue)](https://github.com/johnnychen94)", line)
+                @test occursin("![Author](https://img.shields.io/badge/Author-Jane%20Doe-blue)", line)
+            end
+        end
+    end
 end


### PR DESCRIPTION
Now that we support markdown URL format for the `author` field.

The only thing that we need to be aware of is that double quotes `""` is required when you have `[]()` in the YAML fields; otherwise YAML.jl will complain about it. I'm not a YAML expert so I assume that this is a limitation of YAML.

In markdown:

```markdown
---
author: "[Johnny Chen](https://github.com/johnnychen94)"
---

---
author: "[Johnny Chen](https://github.com/johnnychen94); Jane Doe"
---
```

In Julia:

```julia
# ---
# author: "[Johnny Chen](https://github.com/johnnychen94)"
# ---

# ---
# author: "[Johnny Chen](https://github.com/johnnychen94); Jane Doe"
# ---
```

closes #83