### PR TITLE
allow empty sections when building a page

### DIFF
--- a/src/types/page.jl
+++ b/src/types/page.jl
@@ -130,7 +130,17 @@ function DemoPage(root::String)::DemoPage
     config = parse(Val(:Markdown), template_file)
     config = merge(json_config, config) # template has higher priority over config file
 
-    sections = map(DemoSection, section_paths)
+    sections = filter(map(DemoSection, section_paths)) do sec
+        empty_section = isempty(sec.cards) && isempty(sec.subsections)
+        if empty_section
+            @warn "Empty section detected, remove from the demo page tree." section=relpath(sec.root, root)
+            return false
+        else
+            return true
+        end
+    end
+    isempty(sections) && error("Empty demo page, you have to add something.")
+
     page = DemoPage(root, sections, "", nothing, "", Dict{String, Any}())
     page.theme = load_config(page, "theme"; config=config)
 

--- a/test/types/page.jl
+++ b/test/types/page.jl
@@ -28,6 +28,22 @@ using DemoCards: infer_pagedir, is_demosection, is_democard
     # template has higher priority
     page = DemoPage(joinpath(root, "suppressed_title"))
     @test page.title == "Custom Title"
+
+    @testset "empty demo section" begin
+        page_dir = joinpath("assets", "section", "empty")
+        mkpath(joinpath(page_dir, "sec1")) # empty folder cannot be commited into git history
+
+        page = @suppress_err DemoPage(page_dir)
+        @test length(page.sections) == 1
+        warn_msg = @capture_err DemoPage(page_dir)
+        @test occursin("Empty section detected", warn_msg)
+
+        @test_throws ErrorException("Empty demo page, you have to add something.") @suppress_err begin
+            preview_demos(joinpath("assets", "section", "empty", "sec1"))
+        end
+        @test isempty(readdir(joinpath(page_dir, "sec1")))
+        rm(joinpath(page_dir, "sec1"))
+    end
 end
 
 @testset "infer_pagedir" begin


### PR DESCRIPTION
Instead of throwing an error during building, do some eager check and throw a warning should be fine.