### PR TITLE
Add debug statements - don't prompt on CI

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -154,7 +154,10 @@ function makedemos(source::String, templates::Union{Dict, Nothing} = nothing;
     @info "SetupDemoCardsDirectory: setting up \"$(source)\" directory."
     if isdir(absolute_root)
         # a typical and probably safe case -- that we're still in docs/ folder
-        trigger_prompt = !endswith(dirname(absolute_root), joinpath("docs", "src"))
+        trigger_prompt = (
+            !endswith(dirname(absolute_root), joinpath("docs", "src")) &&
+            !(haskey(ENV, "GITLAB_CI") || haskey(ENV, "GITHUB_ACTIONS"))
+        )
         @info "Deleting folder $absolute_root"
 
         if trigger_prompt
@@ -382,9 +385,11 @@ get_logopath() = joinpath(pkgdir(DemoCards), "assets", "democards_logo.svg")
 recursively process and save source demo file
 """
 function save_democards(root::String, page::DemoPage; kwargs...)
+    @debug page.root
     save_democards.(root, page.sections; properties=page.properties, kwargs...)
 end
 function save_democards(root::String, sec::DemoSection; properties, kwargs...)
+    @debug sec.root
     properties = merge(properties, sec.properties) # sec.properties has higher priority
     save_democards.(joinpath(root, basename(sec.root)), sec.subsections;
                     properties=properties, kwargs...)

--- a/src/types/julia.jl
+++ b/src/types/julia.jl
@@ -141,6 +141,7 @@ function save_democards(card_dir::String,
                         properties = Dict{String, Any}(),
                         kwargs...)
     isdir(card_dir) || mkpath(card_dir)
+    @debug card.path
     cardname = splitext(basename(card.path))[1]
     md_path = joinpath(card_dir, "$(cardname).md")
     nb_path = joinpath(card_dir, "$(cardname).ipynb")

--- a/src/types/markdown.jl
+++ b/src/types/markdown.jl
@@ -108,7 +108,7 @@ function save_democards(card_dir::String,
                         credit,
                         kwargs...)
     isdir(card_dir) || mkpath(card_dir)
-
+    @debug card.path
     markdown_path = joinpath(card_dir, basename(card))
 
     _, _, body = split_frontmatter(read(card.path, String))


### PR DESCRIPTION
- add debug statements `@debug` when `JULIA_DEBUG=DemoCards` is set (for CI): generating card can take some time, and I would want to see if the build is hanging or not, and monitor the progress rate.
- don't prompt on github, gitlab `CI` for dir deletion.